### PR TITLE
Don't use system classloader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run: cd snapshot-matcher && mvn dependency:go-offline
       - run: cd snapshot-matcher && mvn install
       - run: cd snapshot-matcher-example && mvn dependency:go-offline
-      - run: cd snapshot-matcher-example && mvn test
+      - run: cd snapshot-matcher-example && mvn -Dsurefire.useSystemClassLoader=false test
       - save_cache:
           paths:
             - ~/.m2


### PR DESCRIPTION
Tests fail with the following message in CircleCI:
```
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter
```

In this stackoverflow thread https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class, it seems that adding `-Dsurefire.useSystemClassLoader=false` fixes this problem.